### PR TITLE
Add .editorconfig for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,68 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Go files
+[*.go]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# JavaScript/TypeScript files
+[*.{js,ts,jsx,tsx}]
+indent_style = space
+indent_size = 2
+
+# HTML/CSS files
+[*.{html,css,scss,sass}]
+indent_style = space
+indent_size = 2
+
+# Configuration files
+[*.{toml,ini}]
+indent_style = space
+indent_size = 2
+
+# Shell scripts
+[*.{sh,bash}]
+indent_style = space
+indent_size = 2
+
+# Makefile
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+# Docker files
+[Dockerfile*]
+indent_style = space
+indent_size = 2
+
+# Git files
+[.gitignore]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary
- Add .editorconfig file to standardize code formatting across editors
- Improves GitHub web display readability, especially for indentation
- Follows Go language conventions (tabs) while using spaces for other file types

## Changes
- **Go files**: Tab indentation (4-character width) - follows Go standard
- **Markdown files**: Space indentation (2 spaces) - better GitHub display
- **YAML/JSON**: Space indentation (2 spaces) - standard convention
- **Other files**: Appropriate indentation rules for each file type

## Benefits
- Consistent formatting across different editors and IDEs
- Better readability on GitHub web interface
- Maintains Go language coding standards
- Prevents formatting inconsistencies in collaborative development

🤖 Generated with [Claude Code](https://claude.ai/code)